### PR TITLE
Fix code scanning alert no. 3: URL redirection from remote source

### DIFF
--- a/routes.py
+++ b/routes.py
@@ -117,8 +117,12 @@ def login():
         if user and user.check_password(form.password.data):
             login_user(user)
             logging.info(f"User {user.username} logged in successfully")
-            next_page = request.args.get('next')
-            return redirect(next_page or url_for('dashboard'))
+            next_page = request.args.get('next', '')
+            from urllib.parse import urlparse
+            next_page = next_page.replace('\\', '')
+            if not urlparse(next_page).netloc and not urlparse(next_page).scheme:
+                return redirect(next_page or url_for('dashboard'))
+            return redirect(url_for('dashboard'))
         else:
             flash('Invalid username or password', 'danger')
     return render_template('login.html', form=form)


### PR DESCRIPTION
Fixes [https://github.com/WNT3D1/BuilderMaintenancePro/security/code-scanning/3](https://github.com/WNT3D1/BuilderMaintenancePro/security/code-scanning/3)

To fix the problem, we need to validate the `next_page` parameter before using it in a redirect. One way to do this is to ensure that the `next_page` parameter does not contain an explicit host name, which would indicate an external URL. We can use the `urlparse` function from the Python standard library to parse the URL and check that the `netloc` attribute is empty. This ensures that the redirect is only to a relative path within the same site.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
